### PR TITLE
Fix mismatched theme on initial load with giscus

### DIFF
--- a/components/Giscus.tsx
+++ b/components/Giscus.tsx
@@ -7,10 +7,15 @@ const themeMapping = {
 };
 
 export default function Giscus() {
-  const { resolvedTheme = 'light' } = useTheme();
+  const { resolvedTheme } = useTheme();
   const theme = useRef(resolvedTheme);
 
   useEffect(() => {
+    const hasLoaded = theme.current && theme.current !== resolvedTheme;
+    if (!resolvedTheme || hasLoaded) return;
+
+    theme.current = resolvedTheme;
+
     const script = document.createElement('script');
     const attributes = {
       src: 'https://giscus.app/client.js',
@@ -19,17 +24,19 @@ export default function Giscus() {
       'data-repo-id': 'MDEwOlJlcG9zaXRvcnkzNDExNDE2OTY',
       'data-category-id': 'MDE4OkRpc2N1c3Npb25DYXRlZ29yeTMyNzIzMDI4',
       'data-mapping': 'pathname',
-      'data-theme': themeMapping[theme.current as keyof typeof themeMapping],
+      'data-theme': themeMapping[resolvedTheme as keyof typeof themeMapping],
       crossOrigin: 'anonymous',
       async: '',
     };
+
     Object.entries(attributes).forEach(([name, value]) => script.setAttribute(name, value));
     document.body.appendChild(script);
+
     return () => {
       const existingScript = document.body.querySelector('#giscus-script');
       if (existingScript) document.body.removeChild(existingScript);
     };
-  }, []);
+  }, [resolvedTheme]);
 
   useEffect(() => {
     const iframe = document.querySelector<HTMLIFrameElement>('iframe.giscus-frame');


### PR DESCRIPTION
Loading a page that contains giscus directly will cause a mismatched theme to load, because `resolvedTheme` will be `undefined` and it defaults to `light`.